### PR TITLE
add logda from npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const RotatingFileStream = require('bunyan-rotating-file-stream')
 const { exec } = require('child_process')
 const Benchmark = require('benchmark')
 const bunyan = require('bunyan')
-const logda = require('logda')
+const {logda} = require('logda')
 const debug = require('debug')
 const path = require('path')
 const os = require('os')
@@ -14,7 +14,7 @@ const pid = process.pid
 const name = 'test'
 
 const debugLogger = debug(name)
-
+const logdaLogger = logda(name)
 const bunyanLogger = bunyan.createLogger({ name })
 const bunyanRotatingFileLogger = bunyan.createLogger({ 
   name,
@@ -54,8 +54,8 @@ suite.add('bunyan rotating file', function () {
 })
 
 suite.add('logda', function () {
-  logda.info('test')
-  logda.error('test')
+  logdaLogger.info(() => ['test', { name, hostname, pid, type: 'log', time: new Date(), msg: 'test' }])
+  logdaLogger.error(() => ['test', { name, hostname, pid, type: 'log', time: new Date(), msg: 'test' }])
 })
 
 suite.add('debug', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": {
       "version": "1.5.2",
-      "resolved": "http://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
       "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "balanced-match": {
@@ -63,20 +63,20 @@
       "optional": true
     },
     "debug": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
-      "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
       "requires": {
         "ms": "^2.1.1"
       }
     },
     "dtrace-provider": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
-      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.8.tgz",
+      "integrity": "sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==",
       "optional": true,
       "requires": {
-        "nan": "^2.10.0"
+        "nan": "^2.14.0"
       }
     },
     "glob": {
@@ -103,19 +103,20 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "optional": true
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "logda": {
-      "version": "git+https://github.com/JasonPollman/logda.git#15ace3f2eaba24727bcb2705d5eef8ce67a9e668",
-      "from": "git+https://github.com/JasonPollman/logda.git"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/logda/-/logda-1.0.0.tgz",
+      "integrity": "sha512-1DbAkayZ05W73w+suoIYksEIgqAa0gWnHuEcFZBAax1hMerEOlxMjO8VIa0u09sBoOTtY+A6A2tWgw4a384CjQ=="
     },
     "minimatch": {
       "version": "3.0.4",
@@ -128,13 +129,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "optional": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "optional": true,
       "requires": {
@@ -142,15 +143,15 @@
       }
     },
     "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y=",
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
       "optional": true
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "mv": {
       "version": "2.1.1",
@@ -164,14 +165,14 @@
       }
     },
     "nan": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
-      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "optional": true
     },
     "ncp": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
       "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
@@ -185,7 +186,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "optional": true
     },
@@ -196,7 +197,7 @@
     },
     "rimraf": {
       "version": "2.4.5",
-      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
       "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
       "optional": true,
       "requires": {
@@ -210,9 +211,9 @@
       "optional": true
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
     },
     "strftime": {
       "version": "0.9.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "setup": "mkdir ./logs && touch ./logs/rotating-log-file",
     "pretest": "npm run teardown && npm run setup",
     "test": "node index.js",
-    "posttest": "npm run teardown",
     "teardown": "rm -rf ./logs"
   },
   "repository": {
@@ -37,6 +36,6 @@
     "bunyan": "^1.8.12",
     "bunyan-rotating-file-stream": "^1.6.3",
     "debug": "^4.1.0",
-    "logda": "git+https://github.com/JasonPollman/logda.git"
+    "logda": "^1.0.0"
   }
 }


### PR DESCRIPTION
## Description

This adds the logda logger that is published in NPM. Logda can be used in Node and browser environments, so it can be nice to have the benchmark.

After running the test:
```
console x 4,150 ops/sec ±2.27% (46 runs sampled)
stdout x 14,711 ops/sec ±6.56% (77 runs sampled)
bunyan stdout x 15,311 ops/sec ±3.34% (81 runs sampled)
bunyan rotating file x 134,519 ops/sec ±12.47% (60 runs sampled)
logda x 8,192 ops/sec ±1.57% (75 runs sampled)
debug x 3,642 ops/sec ±8.41% (80 runs sampled)
```

## Further considerations 
* I  developed the logda logger that it's published in NPM without knowing  that it was a Node logger named the same but not published, and have seen the logger-benchmark because NPM was showing it as a dependency usage.
* Had to remove the another logda dependency to make it work because of npm package name duplication.
* Take in mind that logda does not log with info level by default.

About the result numbers, I found that the bunyan rotating file version is dropping out the logs because of "write queue saturation", which might not be acceptable in most cases:

![image](https://user-images.githubusercontent.com/20399660/71567151-2f5c8700-2abd-11ea-83bc-19e6ce5f44c1.png)

Anyway, nice job with this benchmark test, didn't knew this benchmark suite utility and I will start using it!! 👌  
